### PR TITLE
Add live reload dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ npm start
 # Dostęp: http://localhost:4200
 ```
 
+### Live reload (backend + frontend jednocześnie)
+1. **Backend** – w pierwszym terminalu uruchom Spring Boot z włączonym DevTools (auto restart po zmianach):
+   ```bash
+   cd backend
+   mvn spring-boot:run
+   ```
+2. **Frontend** – w drugim terminalu odpal Angulara w trybie dev z proxy i live reloadem:
+   ```bash
+   cd frontend/src/main/angular
+   npm install        # tylko za pierwszym razem
+   npm start          # ng serve + proxy -> backend na :8080
+   ```
+3. **Podgląd zmian** – wchodzisz na [http://localhost:4200](http://localhost:4200).
+   - Zmiany w plikach Angulara pojawiają się natychmiast dzięki `ng serve` (hot reload).
+   - Wywołania pod `/api` oraz `/actuator` trafiają automatycznie na backend (proxy z `proxy.conf.json`).
+   - Zmiany w Javie przeładowują się po zapisaniu dzięki Spring Boot DevTools.
+
 ## 🏗 Build na produkcję
 
 ```bash

--- a/frontend/src/main/angular/angular.json
+++ b/frontend/src/main/angular/angular.json
@@ -65,6 +65,11 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "host": "0.0.0.0",
+            "port": 4200,
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "angular-app:build:production"

--- a/frontend/src/main/angular/package.json
+++ b/frontend/src/main/angular/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --port 4200 --proxy-config proxy.conf.json --poll 1000",
     "build": "ng build",
     "build:prod": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",

--- a/frontend/src/main/angular/proxy.conf.json
+++ b/frontend/src/main/angular/proxy.conf.json
@@ -1,0 +1,14 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
+  "/actuator": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}


### PR DESCRIPTION
## Summary
- add an Angular dev-server proxy configuration so the frontend can talk to the Spring Boot backend while running `ng serve`
- extend the npm start script and Angular CLI config to expose the dev server on all interfaces for hot reload
- document the new live-reload workflow in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e9f1d114832ba02c317b22cc6342)